### PR TITLE
購入機能後の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    redirect_to action: :index unless current_user.id == @item.user_id
+    redirect_to action: :index unless (current_user.id == @item.user_id) && @item.purchase.blank?
   end
 
   def update

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,15 +23,13 @@
       </span>
     </div>
 
-  <% if user_signed_in? %>
+  <% if user_signed_in? && @item.purchase.blank? %>
     <% if current_user.id == @item.user_id %>
       <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
     <% else %>
-      <% if @item.purchase.blank? %>
       <%= link_to '購入画面に進む', item_purchases_path(@item.id),  method: :get, class:"item-red-btn"%>
-      <% end %>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
# What
- ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと
- 出品者・出品者以外にかかわらず、ログイン状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
- ログアウト状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、ログインページに遷移すること

# Why
上記の機能を実装し、売却済み商品における表記を整え、ページ遷移の設定をするため