### PR TITLE
パンくずリスト実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,3 +73,4 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'payjp'
 gem "aws-sdk-s3", require: false
+gem 'gretel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,9 @@ GEM
     ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (4.2.0)
+      actionview (>= 5.1, < 7.0)
+      railties (>= 5.1, < 7.0)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -350,6 +353,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  gretel
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,6 +1,6 @@
 <%# cssは商品出品のものを併用しています。
 app/assets/stylesheets/items/new.css %>
-
+<% breadcrumb :items_edit %>
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,6 +1,6 @@
 <%= render "shared/header" %>
 <div class='main'>
-
+  <% breadcrumb :root %>
   <%# 画面上部の「人生を変えるフリマアプリ」帯部分 %>
   <div class='title-contents'>
     <h2 class='service-title'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -3,6 +3,7 @@
 <%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
+    <% breadcrumb :items %>
     <h2 class="name">
       <%= @item.name %>
     </h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
 </head>
 
 <body>
+  <%= breadcrumbs separator: " &rsaquo; " %>
     <%= yield %>
 </body>
 </html>

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -2,6 +2,7 @@
 
 <div class='transaction-contents'>
   <div class='transaction-main'>
+    <% breadcrumb :purchases %>
     <h1 class='transaction-title-text'>
       購入内容の確認
     </h1>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,50 @@
+crumb :root do
+  link "トップページ", root_path
+end
+
+crumb :items do |item|
+  if params[:item_id] == nil
+    item = Item.find(params[:id])
+  else
+    item = Item.find(params[:item_id])
+  end
+  link "商品詳細", item_path(item.id)
+  parent :root
+end
+
+crumb :items_edit do
+  item = Item.find(params[:id])
+  link "商品編集", edit_item_path(item.id)
+  parent :items
+end
+
+crumb :purchases do |item|
+  item = Item.find(params[:item_id])
+  link "商品購入", item_purchases_path(item.id)
+  parent :items
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
# What
商品詳細・商品購入・商品編集のページ上部へtopページを親としたパンくずリストが表示されるよう実装

 # Why
[戻る]ボタンを使わずに希望したページに戻れるようにするため
